### PR TITLE
gx: update go-libp2p-peerstore, go-libp2p, go-libp2p-kbucket

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.8.13: QmYPKo97ssdv3Bsk9sRAS5ZjahGg9Stzys3vybu3r7VuB5
+0.8.14: QmUpeULWfmtsgCnfuRN3BHsfhHvBxNphoYh4La4CMxGt2Z

--- a/package.json
+++ b/package.json
@@ -21,21 +21,21 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmcyNeWPsoFGxThGpV8JnJdfUNankKhWCTrbrcFRQda4xR",
+      "hash": "QmUywuGNZoUKV8B9iyvup9bPkLiMrhTsyVMkeSXW5VxAfC",
       "name": "go-libp2p-host",
-      "version": "1.3.13"
+      "version": "1.3.14"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmcCgouQ5iXfmxmVNc1fpXLacRSPMNHx4tzqDpou6XNvvd",
+      "hash": "Qma2j8dYePrvN5DoNgwh1uAuu3FFtEtrUQFmr737ws8nCp",
       "name": "go-libp2p-netutil",
-      "version": "0.2.14"
+      "version": "0.2.15"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmSwzyZ4zfHD9j4JZdXuzbWH4gXuDfZ7CdfMzpfqrMVcrz",
+      "hash": "Qma4Xhhqtr9tpV814eNjbLHzjuDaRjs96XLcZPJiR742ZV",
       "name": "go-libp2p-blankhost",
-      "version": "0.1.12"
+      "version": "0.1.13"
     }
   ],
   "gxVersion": "0.9.0",
@@ -43,6 +43,6 @@
   "license": "",
   "name": "floodsub",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.8.13"
+  "version": "0.8.14"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-kbucket/pull/8
- https://github.com/libp2p/go-libp2p-routing/pull/10
- https://github.com/libp2p/go-libp2p-kad-dht/pull/60


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace