### PR TITLE
notify: handle new connections asynchronously

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.8.16: QmatoKaefBS5hopnDyMqZUgCjbBRPEi4ktZP5FVruiczbB
+0.8.17: QmYFCNMYp7fR9p2pHDXPGtawfoAYEwrR9GLQbihkB96Krs

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: go
 
 go:
-    - 1.7
+    - 1.8
 
 install: true
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
   "license": "",
   "name": "floodsub",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.8.16"
+  "version": "0.8.17"
 }
 


### PR DESCRIPTION
Trying to create a stream from with a connection notifier is *not* allowed
(and will deadlock).

Also,

* use the pubsub context when trying to open the stream.
* cut a new release...