### PR TITLE
gx: update go-reuseport

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.8.20: Qmar7ei5yhwt1oCExdR1QZQgQxYUuPFV5tsqvPNzaBpGjM
+0.8.21: QmddZj8gx1Ceisj3QEWeAzPEjCPWpXzneN1ANdkZdwUdc3

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmZG4W8GR9FpC4z69Vab9ENtEoxKjDnTym5oa7Q3Yr7P4o",
+      "hash": "QmYdcTdkuCvFXLj2uejJF5aY3HWhtd8JLT4BjPxF9BNPYf",
       "name": "go-libp2p-netutil",
-      "version": "0.2.21"
+      "version": "0.2.22"
     },
     {
       "author": "whyrusleeping",
@@ -72,6 +72,6 @@
   "license": "",
   "name": "floodsub",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.8.20"
+  "version": "0.8.21"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-tcp-transport/pull/10
- https://github.com/libp2p/go-libp2p-conn/pull/13
- https://github.com/libp2p/go-libp2p-swarm/pull/30
- https://github.com/libp2p/go-libp2p-netutil/pull/9
- https://github.com/libp2p/go-libp2p-circuit/pull/11
- https://github.com/libp2p/go-libp2p/pull/218
- https://github.com/libp2p/go-libp2p-kad-dht/pull/83


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace