### PR TITLE
gx: update base32

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.8.21: QmddZj8gx1Ceisj3QEWeAzPEjCPWpXzneN1ANdkZdwUdc3
+0.8.22: QmbSXY15yUrbW1FUeAgQ3m2vtMqiRcJd4ZVgkRKywjkJ7C

--- a/package.json
+++ b/package.json
@@ -21,21 +21,21 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmW8Rgju5JrSMHP7RDNdiwwXyenRqAbtSaPfdQKQC7ZdH6",
+      "hash": "QmcQJspoQP914EDCTemcXz8yQkL4xvc49pTWFhzmifvUZY",
       "name": "go-libp2p-host",
-      "version": "1.3.18"
+      "version": "1.3.19"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYdcTdkuCvFXLj2uejJF5aY3HWhtd8JLT4BjPxF9BNPYf",
+      "hash": "QmQWNh36tpEaJgcoetFFWRpL9tV3Y1tUHx6tVTqbjKd6jP",
       "name": "go-libp2p-netutil",
-      "version": "0.2.22"
+      "version": "0.2.23"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYCDYphqhKPAfyyLQykUMYikhV9a4NhxgQarwNsbQyctu",
+      "hash": "QmSj7CHTCbz8H8aK1EpiuYZtQZT26PK7n9MHJTZsfp6skt",
       "name": "go-libp2p-blankhost",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     {
       "author": "whyrusleeping",
@@ -72,6 +72,6 @@
   "license": "",
   "name": "floodsub",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.8.21"
+  "version": "0.8.22"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/multiformats/go-multibase/pull/17
- https://github.com/ipfs/go-cid/pull/32
- https://github.com/libp2p/go-testutil/pull/11
- https://github.com/libp2p/go-libp2p-conn/pull/14
- https://github.com/libp2p/go-libp2p-connmgr/pull/4
- https://github.com/libp2p/go-libp2p-host/pull/7
- https://github.com/libp2p/go-libp2p-swarm/pull/31
- https://github.com/libp2p/go-libp2p-netutil/pull/10
- https://github.com/libp2p/go-libp2p-blankhost/pull/4
- https://github.com/libp2p/go-libp2p-circuit/pull/13
- https://github.com/libp2p/go-libp2p/pull/220
- https://github.com/libp2p/go-libp2p-kbucket/pull/12
- https://github.com/libp2p/go-libp2p-routing/pull/16
- https://github.com/libp2p/go-libp2p-kad-dht/pull/84


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace