### PR TITLE
drop messages to slow peers

### DIFF
--- a/floodsub.go
+++ b/floodsub.go
@@ -346,6 +346,7 @@ func (p *PubSub) publishMessage(from peer.ID, msg *pb.Message) error {
 		select {
 		case mch <- out:
 		default:
+			log.Infof("dropping message to peer %s: queue full", pid)
 			// Drop it. The peer is too slow.
 		}
 	}

--- a/floodsub.go
+++ b/floodsub.go
@@ -343,7 +343,11 @@ func (p *PubSub) publishMessage(from peer.ID, msg *pb.Message) error {
 			continue
 		}
 
-		go func() { mch <- out }()
+		select {
+		case mch <- out:
+		default:
+			// Drop it. The peer is too slow.
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Instead of spawning a go routine for every message sent to every peer, buffer
them (actually, we already buffer 32 so this didn't need to be changed) and drop
messages when the buffer fills up.

fixes https://github.com/ipfs/go-ipfs/issues/4066

(writing to a channel in a go routine can be dangerous...)