### PR TITLE
Drop announce messages to slow peers

### DIFF
--- a/floodsub.go
+++ b/floodsub.go
@@ -230,8 +230,12 @@ func (p *PubSub) announce(topic string, sub bool) {
 	}
 
 	out := rpcWithSubs(subopt)
-	for _, peer := range p.peers {
-		peer <- out
+	for pid, peer := range p.peers {
+		select {
+		case peer <- out:
+		default:
+			log.Infof("dropping announce message to peer %s: queue full", pid)
+		}
 	}
 }
 

--- a/floodsub.go
+++ b/floodsub.go
@@ -259,6 +259,10 @@ func (p *PubSub) markSeen(id string) {
 // subscribedToMessage returns whether we are subscribed to one of the topics
 // of a given message
 func (p *PubSub) subscribedToMsg(msg *pb.Message) bool {
+	if len(p.myTopics) == 0 {
+		return false
+	}
+
 	for _, t := range msg.GetTopicIDs() {
 		if _, ok := p.myTopics[t]; ok {
 			return true


### PR DESCRIPTION
Very similar to https://github.com/libp2p/go-floodsub/pull/34, only this protects the main loop from getting stuck announcing to a slow peer.

I also added a small optimization to `subscribedToMsg` to check to see if our topic list is empty before iterating through the topics in the message.