### PR TITLE
Rename gx package to go-libp2p-floodsub

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
   "gxVersion": "0.9.0",
   "language": "go",
   "license": "",
-  "name": "floodsub",
+  "name": "go-libp2p-floodsub",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
   "version": "0.9.3"
 }
-


### PR DESCRIPTION
Resolves https://github.com/libp2p/go-floodsub/issues/7

Should be easy to coordinate this change with go-ipfs, etc. I would worry about others using this lib, but it's still beta software, so I think it's fine to switch the package name now.