### PR TITLE
gx: update go-peerstream

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.9.3: QmPGT8xqmDnbCbc5HCpjSCzPw7HcsSKuzVAWGjAtF3oftm
+0.9.4: QmUUSLfvihARhCxxgnjW4hmycJpPvzNu12Aaz6JWVdfnLg

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmdzuGp4a9pahgXuBeReHdYGUzdVX3FUCwfmWVo5mQfkTi",
+      "hash": "QmQGX417WoxKxDJeHqouMEmmH4G1RCENNSzkZYHrXy3Xb3",
       "name": "go-libp2p-netutil",
-      "version": "0.3.2"
+      "version": "0.3.3"
     },
     {
       "author": "whyrusleeping",
@@ -72,5 +72,6 @@
   "license": "",
   "name": "go-libp2p-floodsub",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.9.3"
+  "version": "0.9.4"
 }
+


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-swarm/pull/39
- https://github.com/libp2p/go-libp2p-netutil/pull/13
- https://github.com/libp2p/go-libp2p-circuit/pull/21
- https://github.com/libp2p/go-libp2p/pull/239
- https://github.com/libp2p/go-libp2p-kad-dht/pull/97


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace