### PR TITLE
TestSubscribeMultipleTimes fails go test -race.

### DIFF
--- a/floodsub.go
+++ b/floodsub.go
@@ -253,7 +253,6 @@ func (p *PubSub) announce(topic string, sub bool) {
 }
 
 // notifySubs sends a given message to all corresponding subscribers.
-// A topic must have a subscription(s), otherwise notifySubs fails.
 // Only called from maybePublishMessage.
 func (p *PubSub) notifySubs(msg *pb.Message) {
 	for _, topic := range msg.GetTopicIDs() {

--- a/floodsub.go
+++ b/floodsub.go
@@ -252,8 +252,9 @@ func (p *PubSub) announce(topic string, sub bool) {
 	}
 }
 
-// notifySubs sends a given message to all corresponding subscribbers.
-// Only called from processLoop.
+// notifySubs sends a given message to all corresponding subscribers.
+// A topic must have a subscription(s), otherwise notifySubs fails.
+// Only called from maybePublishMessage.
 func (p *PubSub) notifySubs(msg *pb.Message) {
 	for _, topic := range msg.GetTopicIDs() {
 		subs := p.myTopics[topic]

--- a/floodsub.go
+++ b/floodsub.go
@@ -253,7 +253,7 @@ func (p *PubSub) announce(topic string, sub bool) {
 }
 
 // notifySubs sends a given message to all corresponding subscribers.
-// Only called from maybePublishMessage.
+// Only called from processLoop.
 func (p *PubSub) notifySubs(msg *pb.Message) {
 	for _, topic := range msg.GetTopicIDs() {
 		subs := p.myTopics[topic]

--- a/floodsub_test.go
+++ b/floodsub_test.go
@@ -524,7 +524,7 @@ func TestSubscribeMultipleTimes(t *testing.T) {
 	}
 
 	// make sure subscribing is finished by the time we publish
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	psubs[1].Publish("foo", []byte("bar"))
 


### PR DESCRIPTION
TestSubscribeMultipleTimes consistently fails `go test -race` locally.
This may explain why it's a flappy test in CI (see https://github.com/libp2p/go-floodsub/issues/22).

Specifically to this test, not enough time is given for Subscribe to finish before Publish is executed.
On making this change, `libp2p/go-floodsub` passes `go test -count=2 -race` locally.