### PR TITLE
package.json: Import libp2p and not separate deps

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.9.13: QmduQtUFqdq2RhM84yM2mYsdgJRAH8Aukb15viDxWkZtvP
+0.9.14: QmPynuWZTkJA2aYNwL1SBMdHGeHAndxK5Ap1attWnxdfua

--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.9.12: QmVKrsEgixRtMWcMd6WQzuwqCUC3jfLf7Q7xcjnKoMMikS
+0.9.13: QmduQtUFqdq2RhM84yM2mYsdgJRAH8Aukb15viDxWkZtvP

--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
   "license": "",
   "name": "go-libp2p-floodsub",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.9.12"
+  "version": "0.9.13"
 }
+

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmNh1kGFFdsPu79KNSaL4NUKUPb4Eiz4KHdMtFY6664RDp",
+      "hash": "QmWsV6kzPaYGBDVyuUfWBvyQygEc9Qrv9vzo8vZ7X4mdLN",
       "name": "go-libp2p",
-      "version": "5.0.14"
+      "version": "5.0.17"
     }
   ],
   "gxVersion": "0.9.0",
@@ -31,6 +31,6 @@
   "license": "",
   "name": "go-libp2p-floodsub",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.9.13"
+  "version": "0.9.14"
 }
 

--- a/package.json
+++ b/package.json
@@ -21,50 +21,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmfZTdmunzKzAGJrSvXXQbQ5kLLUiEMX5vdwux7iXkdk7D",
-      "name": "go-libp2p-host",
-      "version": "2.1.7"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "Qmb6BsZf6Y3kxffXMNTubGPF1w1bkHtpvhfYbmnwP3NQyw",
-      "name": "go-libp2p-netutil",
-      "version": "0.3.11"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "Qmc64U41EEB4nPG7wxjEqFwKJajS2f8kk5q2TvUrQf78Xu",
-      "name": "go-libp2p-blankhost",
-      "version": "0.2.7"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmXoz9o2PT3tEzf7hicegwex5UgVP54n3k82K7jrWFyN86",
-      "name": "go-libp2p-net",
-      "version": "2.0.7"
-    },
-    {
-      "hash": "QmTG23dvpBCBjqQwyDxV8CQT6jmS4PSftNr1VqHhE3MLy7",
-      "name": "go-log",
-      "version": "1.4.1"
-    },
-    {
-      "author": "multiformats",
-      "hash": "QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb",
-      "name": "go-multiaddr",
-      "version": "1.2.6"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmcJukH2sAFjY3HdBKq35WDzWoL3UUu2gt9wdfqZTUyM74",
-      "name": "go-libp2p-peer",
-      "version": "2.3.2"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN",
-      "name": "go-libp2p-protocol",
-      "version": "1.0.0"
+      "hash": "QmNh1kGFFdsPu79KNSaL4NUKUPb4Eiz4KHdMtFY6664RDp",
+      "name": "go-libp2p",
+      "version": "5.0.14"
     }
   ],
   "gxVersion": "0.9.0",
@@ -74,4 +33,3 @@
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
   "version": "0.9.12"
 }
-


### PR DESCRIPTION
This project builds on top of libp2p but imports separate
libp2p libraries instead of the main package. This makes it
difficult to use while using libp2p. i.e. when a host has been
created with libp2p.New() and the libp2p-peer version does not
match the one here.