### PR TITLE
some logging for gossipsub

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.9.23: QmRXefkwjreRT6XfYh3Ag4hsVnWBbpcUicGJPcg8TWbhBK
+0.9.24: QmWEwoF9gZAGNevKxFo4q216DCo9ieui5ZAe5jSZCdesck

--- a/package.json
+++ b/package.json
@@ -72,6 +72,5 @@
   "license": "",
   "name": "go-libp2p-floodsub",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.9.23"
+  "version": "0.9.24"
 }
-


### PR DESCRIPTION
The pubsub routers are very quiet, which can make it hard to diagnose the network state.
That's probably ok for floodsub, as the router doesn't do much, but gossipsub could be more verbose.

This pr adds some basic event logging to gossipsub router, so that we can have a clue about network state when debugging.