### PR TITLE
fix: recover panics from topic validators

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -366,8 +366,10 @@ loop:
 		select {
 		case v.validateThrottle <- struct{}{}:
 			go func() {
+				defer func() {
+					<-v.validateThrottle
+				}()
 				v.doValidateTopic(async, src, msg, result, onValid)
-				<-v.validateThrottle
 			}()
 		default:
 			v.p.logger.Debug("message validation throttled; dropping message from peer", "peer", src)
@@ -440,8 +442,10 @@ func (v *validation) validateTopic(vals []*validatorImpl, src peer.ID, msg *Mess
 		select {
 		case val.validateThrottle <- struct{}{}:
 			go func(val *validatorImpl) {
+				defer func() {
+					<-val.validateThrottle
+				}()
 				rch <- val.validateMsg(ctx, src, msg)
-				<-val.validateThrottle
 			}(val)
 
 		default:
@@ -476,8 +480,10 @@ loop:
 func (v *validation) validateSingleTopic(val *validatorImpl, src peer.ID, msg *Message) ValidationResult {
 	select {
 	case val.validateThrottle <- struct{}{}:
+		defer func() {
+			<-val.validateThrottle
+		}()
 		res := val.validateMsg(v.p.ctx, src, msg)
-		<-val.validateThrottle
 		return res
 
 	default:
@@ -486,10 +492,16 @@ func (v *validation) validateSingleTopic(val *validatorImpl, src peer.ID, msg *M
 	}
 }
 
-func (val *validatorImpl) validateMsg(ctx context.Context, src peer.ID, msg *Message) ValidationResult {
+func (val *validatorImpl) validateMsg(ctx context.Context, src peer.ID, msg *Message) (res ValidationResult) {
 	start := time.Now()
 	defer func() {
 		val.logger.Debug("validation done", "duration", time.Since(start))
+	}()
+	defer func() {
+		if r := recover(); r != nil {
+			val.logger.Error("panic in message validator", "peer", src, "topic", val.topic, "panic", r)
+			res = ValidationReject
+		}
 	}()
 
 	if val.validateTimeout > 0 {

--- a/validation_test.go
+++ b/validation_test.go
@@ -167,6 +167,113 @@ func TestValidate2(t *testing.T) {
 	})
 }
 
+func TestValidatePanicRecovery(t *testing.T) {
+	synctestTest(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		hosts := getDefaultHosts(t, 2)
+		sender, err := NewGossipSub(ctx, hosts[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		receiver, err := NewGossipSub(ctx, hosts[1])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		connect(t, hosts[0], hosts[1])
+		topic := "panic-validator-single"
+
+		err = receiver.RegisterTopicValidator(topic,
+			func(ctx context.Context, from peer.ID, msg *Message) bool {
+				if bytes.Equal(msg.Data, []byte("panic")) {
+					panic("validator panic")
+				}
+				return true
+			},
+			WithValidatorConcurrency(1))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		sub, err := receiver.Subscribe(topic)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(50 * time.Millisecond)
+
+		if err := sender.Publish(topic, []byte("panic")); err != nil {
+			t.Fatal(err)
+		}
+
+		assertNeverReceives(t, sub, 200*time.Millisecond)
+
+		if err := sender.Publish(topic, []byte("ok")); err != nil {
+			t.Fatal(err)
+		}
+
+		assertReceive(t, sub, []byte("ok"))
+	})
+}
+
+func TestValidatePanicRecoveryMulti(t *testing.T) {
+	synctestTest(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		topic := "panic-validator-multi"
+		hosts := getDefaultHosts(t, 2)
+		sender, err := NewGossipSub(ctx, hosts[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		receiver, err := NewGossipSub(ctx, hosts[1],
+			WithDefaultValidator(
+				func(ctx context.Context, from peer.ID, msg *Message) bool {
+					if bytes.Equal(msg.Data, []byte("panic")) {
+						panic("default validator panic")
+					}
+					return true
+				},
+				WithValidatorConcurrency(1)))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		connect(t, hosts[0], hosts[1])
+
+		err = receiver.RegisterTopicValidator(topic,
+			func(ctx context.Context, from peer.ID, msg *Message) bool {
+				return true
+			},
+			WithValidatorConcurrency(1))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		sub, err := receiver.Subscribe(topic)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(50 * time.Millisecond)
+
+		if err := sender.Publish(topic, []byte("panic")); err != nil {
+			t.Fatal(err)
+		}
+
+		assertNeverReceives(t, sub, 200*time.Millisecond)
+
+		if err := sender.Publish(topic, []byte("ok")); err != nil {
+			t.Fatal(err)
+		}
+
+		assertReceive(t, sub, []byte("ok"))
+	})
+}
+
 func TestValidateOverload(t *testing.T) {
 	type msg struct {
 		msg       []byte


### PR DESCRIPTION
## Issue

This PR fixes a crash path in the pubsub validation pipeline when an application-provided topic validator panics.

Incoming messages are passed through registered validators before they are delivered to local subscribers or forwarded through the network. Some applications use these validators to parse message payloads, check application-level rules, or reject malformed data. If that validator code hits an unexpected edge case and panics, the panic could previously escape the validation path.

This is especially risky in the async validation flow. Async validators run inside goroutines, and in Go an unrecovered panic in any goroutine terminates the whole process. That means a remote peer could send a message that triggers a panic bug in application validation code and cause the node process to exit instead of just dropping that message. The old code also released validation throttle tokens only after the validator returned normally, so panic paths could skip cleanup.

## Fix

This change catches panics at the validator boundary in `validateMsg`.

If a validator panics, pubsub now logs the panic with peer and topic context, then treats the result as `ValidationReject`. The message is dropped through the normal validation failure path, and the process continues running. This keeps validator bugs isolated to the message being validated instead of letting them crash the node.

The validation throttle cleanup is also moved into deferred cleanup blocks. This makes sure throttle tokens are released even when validation exits through a panic. The recovery is intentionally scoped to the application validator call, so internal pubsub programming errors are not broadly hidden.

## Tests

This PR adds regression tests for both async validation paths.

`TestValidatePanicRecovery` covers the normal async topic validator path. It sends a message that causes the validator to panic, verifies that the message is not delivered, then sends a valid message and checks that validation still works afterward.

`TestValidatePanicRecoveryMulti` covers the multi-validator path where validators run concurrently. It verifies the same behavior there: a panicking validator rejects the bad message, does not crash the process, and does not prevent a later valid message from being delivered.

